### PR TITLE
Add .gitattributes file to repo.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# all files in scripts directory, and all *.sh files, are linux scripts and must retain LF line endings.
+nuodb/scripts/*   text eol=lf
+*.sh              text eol=lf


### PR DESCRIPTION
Add .gitattributes file to ensure linux scripts retain their LF line endings even on Windows clients.