### PR TITLE
Ntj/license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ nuodb/*.tgz
 nuodb/*.tar.gz
 .DS_Store
 nuodb/.DS_Store
+nuodb/*.lic

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Note that all container names will have the `project` name embedded, which is th
 1. Copy the `env-default` file to `.env` (this step is _NOT_ optional).
 
 1. If using NuoDB v6.0.2 or greater, acquire a NuoDB license file.
-   - If you or your organisation do not have a valid NuoDB license file, contact NuoDB support to request one: NuoDB.Support@3ds.com.
+   - If you or your organisation do not have a valid NuoDB license file, contact NuoDB support to request one: NuoDB.Support...at...3ds.com.
    - Store your NuoDB license file somewhere on your local disk
 
 1. Edit the `.env` file:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Note that all container names will have the `project` name embedded, which is th
 
 2. Copy the `env-default` file to `.env` (this step is _NOT_ optional).
 
-3. Edit the `.env` file:
+3. If using NuoDB v6 or greater, acquire a NuoDB license file.
+   - If you or your organisation do not have a valid NuoDB license file, contact NuoDB support to request one.
+   - store your NuoDB license file somewhere on your local disk
+
+4. Edit the `.env` file:
     - `ENGINE_MEM`
       - Sets the memory cache size for each TE and SM.
     - `SQL_ENGINE`:
@@ -70,6 +74,9 @@ Note that all container names will have the `project` name embedded, which is th
         - either in the `.env` file, _or_ by setting `EXTERNAL_ADDRESS` on the `docker compose up` command-line (Linux/MacOS) or by first setting `EXTERNAL_ADDRESS` as an environment variable (Windows);
         - set to the address of the local host machine (Ex `192.168.0.123`);
         - on some platforms, setting `EXTERNAL_ADDRESS` to `127.0.0.1` also works;
+    - `LICENSE_PATH` :
+      - If you have a valid NuoDB license file - per step #3 above - then set `LICENSE_PATH` to point to that file path.
+        - Eg: `LICENSE_PATH=./nuodb.lic`
     - `IMPORT_LOCAL`, `IMPORT_REMOTE`, `IMPORT_TIMEOUT`, `IMPORT_AUTH`, `IMPORT_LEVEL`
       - If you want to import initial state from a database backup into the new database, set `IMPORT_LOCAL` and/or `IMPORT_REMOTE` (see `Notes` below for details of `IMPORT_LOCAL` and `IMPORT_REMOTE`);
         - the `import` operation is only performed when the archive dir is _empty_ - so the SM container can be stopped and restarted without being reinitialized each time.
@@ -86,11 +93,12 @@ However, with newer versions of `docker` both `docker-compose` _and_ `docker com
   - `docker compose ... stop ...`;
 - A stopped database can be `restarted` and will _CONTINUE_ using its previous existing storage:
   - `docker compose ... start ...`;
+  - this is often needed after a host machine has been woken up after sleep/hibernation.
 - A database is `deleted` _WITH_ its storage using:
   - `docker compose ... down`;
 - A client app connects to a database by configuring a port on the host network - set with the variable `EXTERNAL_ADDRESS` - into its connection string/params;
   - example: `EXTERNAL_ADDRESS=192.167.0.123` if the local host's network address is `192.168.0.123`
-  - example: `EXTERNAL_ADDRESS=localhost` if `docker` can resolve 
+  - example: `EXTERNAL_ADDRESS=localhost` if `docker` can resolve `localhst`.
 - Because `docker compose` does not scope the Docker networks it creates to a particular file or profile, `docker compose ... down` may attempt to delete a network that is still in use by a different database.
   The error looks like the following, and can be ignored:
 

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ Note that all container names will have the `project` name embedded, which is th
 
 ### Getting Started ##
 
-0. Clone this repo.
+1. Clone this repo.
 
 1. `cd` to the `nuodb` directory.
 
-2. Copy the `env-default` file to `.env` (this step is _NOT_ optional).
+1. Copy the `env-default` file to `.env` (this step is _NOT_ optional).
 
-3. If using NuoDB v6 or greater, acquire a NuoDB license file.
-   - If you or your organisation do not have a valid NuoDB license file, contact NuoDB support to request one.
-   - store your NuoDB license file somewhere on your local disk
+1. If using NuoDB v6.0.2 or greater, acquire a NuoDB license file.
+   - If you or your organisation do not have a valid NuoDB license file, contact NuoDB support to request one: NuoDB.Support@3ds.com.
+   - Store your NuoDB license file somewhere on your local disk
 
-4. Edit the `.env` file:
+1. Edit the `.env` file:
     - `ENGINE_MEM`
       - Sets the memory cache size for each TE and SM.
     - `SQL_ENGINE`:

--- a/nuodb/docker-compose.yaml
+++ b/nuodb/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
     volumes:
       - ./scripts:/usr/local/scripts
       - ./scripts/stop-nuodb:/usr/local/bin/stop-nuodb
+      - ${LICENSE_PATH:-./empty-file}:/etc/nuodb/nuodb.lic
     
     command: [ "/usr/local/scripts/start-nuoadmin" ]
 

--- a/nuodb/env-default
+++ b/nuodb/env-default
@@ -17,6 +17,10 @@ ENGINE_MEM=1Gi
 SQL_ENGINE=vee
 LOGDIR=/var/log/nuodb
 
+# local path to a NuoDB license file
+# Contact NuoDB support on NuoDB.support at 3ds.com to request a license.
+LICENSE_PATH=
+
 # docker compose restart policy.
 # Set to one of:
 # - "no"

--- a/nuodb/env-default
+++ b/nuodb/env-default
@@ -8,7 +8,7 @@
 #   Set as an environment variable (all platforms).
 #   Value set in .env file.
 
-NUODB_IMAGE=nuodb/nuodb-ce:5.0.1-2
+NUODB_IMAGE=nuodb/nuodb-ce:5.1.2-5
 
 DB_NAME=demo
 DB_USER=dba

--- a/nuodb/instadb.yaml
+++ b/nuodb/instadb.yaml
@@ -28,7 +28,8 @@ services:
     volumes:
       - ./scripts:/usr/local/scripts
       - ./scripts/stop-nuodb:/usr/local/bin/stop-nuodb
-      - ${IMPORT_LOCAL:-./empty-file}:${IMPORT_MOUNT:-/var/tmp/env}  
+      - ${IMPORT_LOCAL:-./empty-file}:${IMPORT_MOUNT:-/var/tmp/env}
+      - ${LICENSE_PATH:-./empty-file}:/etc/nuodb/nuodb.lic
 
     command: [ "/usr/local/scripts/start-monolith" ]
 

--- a/nuodb/monolith.yaml
+++ b/nuodb/monolith.yaml
@@ -29,7 +29,8 @@ services:
     volumes:
       - ./scripts:/usr/local/scripts
       - ./scripts/stop-nuodb:/usr/local/bin/stop-nuodb
-      - ${IMPORT_LOCAL:-./empty-file}:${IMPORT_MOUNT:-/var/tmp/env}  
+      - ${IMPORT_LOCAL:-./empty-file}:${IMPORT_MOUNT:-/var/tmp/env}
+      - ${LICENSE_PATH:-./empty-file}:/etc/nuodb/nuodb.lic
 
     command: [ "/usr/local/scripts/start-monolith" ]  
 


### PR DESCRIPTION
Add the ability to inject a NuoDB license file into any of the configurations.
From NuoDB 6.0, NuoDB will refuse to start any engines if it does not have a valid license enabled.

Update the README file to reflect the changes, and to fix various typos, comply with recent NuoDB Doc standards, and to clarify various points.

A local NuoDB license file can be mounted into the appropriate NuoDB container as a volume.
The user needs provide the license file, and adjust the config to point to this file, in order for it to be injected, and recognised.